### PR TITLE
Be able to ignore change for cluster as group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ resource "aws_launch_template" "container_instance" {
 resource "aws_autoscaling_group" "container_instance" {
   lifecycle {
     create_before_destroy = true
-    ignore_changes = "${var.autoscaling_group_lifecycle_ignore_changes}"
+    ignore_changes = "desired_capacity"
   }
 
   name = "${coalesce(var.autoscaling_group_name, local.autoscaling_group_name)}"

--- a/main.tf
+++ b/main.tf
@@ -179,6 +179,7 @@ resource "aws_launch_template" "container_instance" {
 resource "aws_autoscaling_group" "container_instance" {
   lifecycle {
     create_before_destroy = true
+    ignore_changes = "${var.autoscaling_group_lifecycle_ignore_changes}"
   }
 
   name = "${coalesce(var.autoscaling_group_name, local.autoscaling_group_name)}"

--- a/variables.tf
+++ b/variables.tf
@@ -98,3 +98,8 @@ variable "enabled_metrics" {
 variable "subnet_ids" {
   type = "list"
 }
+
+variable "autoscaling_group_lifecycle_ignore_changes" {
+  type = "list"
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -99,7 +99,3 @@ variable "subnet_ids" {
   type = "list"
 }
 
-variable "autoscaling_group_lifecycle_ignore_changes" {
-  type = "list"
-  default = []
-}


### PR DESCRIPTION
sometime, it will be helpful to have `desired_capacity` ignored in the cluster auto scaling group.
cause it's dangerous for user to apply `desired_capacity` on a running ECS cluster.
This PR try to enable it, I want to implement it as an optional, but unfortunately it cant https://github.com/hashicorp/terraform/issues/3116, so just hardcode it.

