### PR TITLE
Support condiontal device mappings

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,4 +4,35 @@ locals {
   security_group_name           = "sgContainerInstance"
   ecs_for_ec2_service_role_name = "${var.environment}ContainerInstanceProfile"
   ecs_service_role_name         = "ecs${title(var.environment)}ServiceRole"
+
+  root_device = {
+    device_name = "${var.lookup_latest_ami ? join("", data.aws_ami.ecs_ami.*.root_device_name) : join("", data.aws_ami.user_ami.*.root_device_name)}"
+
+    ebs = [{
+      volume_type = "${var.root_block_device_type}"
+      volume_size = "${var.root_block_device_size}"
+    }]
+  }
+
+  data_device = {
+    device_name = "${var.data_block_device_name}"
+
+    ebs = [{
+      volume_type = "${var.data_block_device_type}"
+      volume_size = "${var.data_block_device_size}"
+    }]
+  }
+
+  voloume_devices_without_data = [
+    "${local.root_device}",
+  ]
+
+  voloume_devices_with_data = [
+    "${local.root_device}",
+    "${local.data_device}",
+  ]
+
+  //  https://github.com/hashicorp/terraform/issues/12453#issuecomment-311611817
+  volume_end_index = "${var.enable_data_block_device ? 2 : 1}"
+  voloume_devices = "${slice(local.voloume_devices_with_data, 0, local.volume_end_index)}"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -23,16 +23,16 @@ locals {
     }]
   }
 
-  voloume_devices_without_data = [
+  volume_devices_without_data = [
     "${local.root_device}",
   ]
 
-  voloume_devices_with_data = [
+  volume_devices_with_data = [
     "${local.root_device}",
     "${local.data_device}",
   ]
 
   //  https://github.com/hashicorp/terraform/issues/12453#issuecomment-311611817
   volume_end_index = "${var.enable_data_block_device ? 2 : 1}"
-  voloume_devices = "${slice(local.voloume_devices_with_data, 0, local.volume_end_index)}"
+  volume_devices = "${slice(local.volume_devices_with_data, 0, local.volume_end_index)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -140,14 +140,16 @@ data "aws_ami" "user_ami" {
 }
 
 resource "aws_launch_template" "container_instance" {
-  block_device_mappings {
-    device_name = "${var.lookup_latest_ami ? join("", data.aws_ami.ecs_ami.*.root_device_name) : join("", data.aws_ami.user_ami.*.root_device_name)}"
+  block_device_mappings = [
+    {
+      device_name = "${var.lookup_latest_ami ? join("", data.aws_ami.ecs_ami.*.root_device_name) : join("", data.aws_ami.user_ami.*.root_device_name)}"
 
-    ebs {
-      volume_type = "${var.root_block_device_type}"
-      volume_size = "${var.root_block_device_size}"
+      ebs = [{
+        volume_type = "${var.root_block_device_type}"
+        volume_size = "${var.root_block_device_size}"
+      }]
     }
-  }
+  ]
 
   credit_specification {
     cpu_credits = "${var.cpu_credit_specification}"

--- a/main.tf
+++ b/main.tf
@@ -140,16 +140,7 @@ data "aws_ami" "user_ami" {
 }
 
 resource "aws_launch_template" "container_instance" {
-  block_device_mappings = [
-    {
-      device_name = "${var.lookup_latest_ami ? join("", data.aws_ami.ecs_ami.*.root_device_name) : join("", data.aws_ami.user_ami.*.root_device_name)}"
-
-      ebs = [{
-        volume_type = "${var.root_block_device_type}"
-        volume_size = "${var.root_block_device_size}"
-      }]
-    }
-  ]
+  block_device_mappings = ["${local.voloume_devices}"]
 
   credit_specification {
     cpu_credits = "${var.cpu_credit_specification}"

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,22 @@ variable "root_block_device_size" {
   default = "8"
 }
 
+variable "enable_data_block_device" {
+  default = 0
+}
+
+variable "data_block_device_name" {
+  default = "/dev/xvdb"
+}
+
+variable "data_block_device_type" {
+  default = "gp2"
+}
+
+variable "data_block_device_size" {
+  default = "50"
+}
+
 variable "instance_type" {
   default = "t2.micro"
 }


### PR DESCRIPTION
This PR makes it support to provision ECS instance with additional EBS volume attached as data volume.
Disable by default, so it keep backward compatible.